### PR TITLE
fix: add namespace `doom` for not collapsing with range-v3 library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ target_sources(doom_meta INTERFACE ${META_SOURCES})
 
 target_include_directories(doom_meta INTERFACE include)
 
-option(META_BUILD_TESTS "Build tests of the meta library" OFF)
+option(META_BUILD_TESTS "Build tests of the meta library" ON)
 
 if (META_BUILD_TESTS)
     set(CMAKE_CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ target_sources(doom_meta INTERFACE ${META_SOURCES})
 
 target_include_directories(doom_meta INTERFACE include)
 
-option(META_BUILD_TESTS "Build tests of the meta library" ON)
+option(META_BUILD_TESTS "Build tests of the meta library" OFF)
 
 if (META_BUILD_TESTS)
     set(CMAKE_CXX_STANDARD 17)

--- a/include/meta/detection/detection.hpp
+++ b/include/meta/detection/detection.hpp
@@ -7,7 +7,7 @@
 
 #include <type_traits>
 
-namespace meta
+namespace doom::meta
 {
     template <typename, template <typename ...> typename MetaF, typename ...Args>
     struct is_detected : std::false_type

--- a/include/meta/sequence/all.hpp
+++ b/include/meta/sequence/all.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/sequence/unordered_map.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/any.hpp
+++ b/include/meta/sequence/any.hpp
@@ -7,7 +7,7 @@
 
 #include <meta/sequence/list.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/append.hpp
+++ b/include/meta/sequence/append.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/sequence/unordered_map.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/at.hpp
+++ b/include/meta/sequence/at.hpp
@@ -10,7 +10,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/sequence/unordered_map.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/concat.hpp
+++ b/include/meta/sequence/concat.hpp
@@ -7,7 +7,7 @@
 
 #include <meta/sequence/list.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/cons.hpp
+++ b/include/meta/sequence/cons.hpp
@@ -7,7 +7,7 @@
 
 #include <meta/sequence/list.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/details/drop_helper.hpp
+++ b/include/meta/sequence/details/drop_helper.hpp
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-namespace meta
+namespace doom::meta
 {
     template <typename ...Types>
     struct list;

--- a/include/meta/sequence/details/flatten_helper.hpp
+++ b/include/meta/sequence/details/flatten_helper.hpp
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-namespace meta
+namespace doom::meta
 {
     template <typename ...Types>
     struct list;

--- a/include/meta/sequence/details/foldl_helper.hpp
+++ b/include/meta/sequence/details/foldl_helper.hpp
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-namespace meta
+namespace doom::meta
 {
     template <typename ...Types>
     struct list;

--- a/include/meta/sequence/details/index_helper.hpp
+++ b/include/meta/sequence/details/index_helper.hpp
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-namespace meta
+namespace doom::meta
 {
     template <typename ...Types>
     struct list;

--- a/include/meta/sequence/details/pow2.hpp
+++ b/include/meta/sequence/details/pow2.hpp
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-namespace meta::details
+namespace doom::meta::details
 {
     /**
      * Get the exponent needed to obtain a power of two greater than the given number

--- a/include/meta/sequence/details/rotate_helper.hpp
+++ b/include/meta/sequence/details/rotate_helper.hpp
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-namespace meta
+namespace doom::meta
 {
     template <typename ...Types>
     struct list;

--- a/include/meta/sequence/drop.hpp
+++ b/include/meta/sequence/drop.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/sequence/details/drop_helper.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/drop_at.hpp
+++ b/include/meta/sequence/drop_at.hpp
@@ -10,7 +10,7 @@
 #include <meta/sequence/concat.hpp>
 #include <meta/sequence/list.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/filter.hpp
+++ b/include/meta/sequence/filter.hpp
@@ -12,7 +12,7 @@
 #include <meta/sequence/flatten.hpp>
 #include <meta/sequence/from_list.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/flatten.hpp
+++ b/include/meta/sequence/flatten.hpp
@@ -9,7 +9,7 @@
 #include <meta/sequence/details/flatten_helper.hpp>
 #include <meta/sequence/list.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/foldl.hpp
+++ b/include/meta/sequence/foldl.hpp
@@ -9,7 +9,7 @@
 #include <meta/sequence/unordered_map.hpp>
 #include <meta/sequence/details/foldl_helper.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/from_list.hpp
+++ b/include/meta/sequence/from_list.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/sequence/unordered_map.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/head.hpp
+++ b/include/meta/sequence/head.hpp
@@ -9,7 +9,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/sequence/at.hpp>
 
-namespace meta
+namespace doom::meta
 {
     template <typename Sequence>
     using head = at<Sequence, size_constant<0>>;

--- a/include/meta/sequence/index.hpp
+++ b/include/meta/sequence/index.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/sequence/details/index_helper.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/init.hpp
+++ b/include/meta/sequence/init.hpp
@@ -9,7 +9,7 @@
 #include <meta/sequence/size.hpp>
 #include <meta/utils/integral_constants.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/insert_at.hpp
+++ b/include/meta/sequence/insert_at.hpp
@@ -10,7 +10,7 @@
 #include <meta/sequence/join.hpp>
 #include <meta/sequence/cons.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/join.hpp
+++ b/include/meta/sequence/join.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/sequence/flatten.hpp>
 
-namespace meta
+namespace doom::meta
 {
     /**
      * Join multiple sequences

--- a/include/meta/sequence/last.hpp
+++ b/include/meta/sequence/last.hpp
@@ -10,7 +10,7 @@
 #include <meta/sequence/at.hpp>
 #include <meta/sequence/size.hpp>
 
-namespace meta
+namespace doom::meta
 {
     template <typename Sequence>
     using last = at<Sequence, size_constant<size<Sequence>::value - 1>>;

--- a/include/meta/sequence/list.hpp
+++ b/include/meta/sequence/list.hpp
@@ -7,7 +7,7 @@
 
 #include <type_traits>
 
-namespace meta
+namespace doom::meta
 {
     template <typename ...Types>
     struct list

--- a/include/meta/sequence/map.hpp
+++ b/include/meta/sequence/map.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/sequence/unordered_map.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/minimum.hpp
+++ b/include/meta/sequence/minimum.hpp
@@ -12,7 +12,7 @@
 #include <meta/sequence/size.hpp>
 #include <meta/utils/meta_functions.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/none.hpp
+++ b/include/meta/sequence/none.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/sequence/unordered_map.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/repeat.hpp
+++ b/include/meta/sequence/repeat.hpp
@@ -8,7 +8,7 @@
 #include <utility>
 #include <meta/sequence/list.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/replace.hpp
+++ b/include/meta/sequence/replace.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/map.hpp>
 #include <meta/utils/meta_functions.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/replicate.hpp
+++ b/include/meta/sequence/replicate.hpp
@@ -8,7 +8,7 @@
 #include <utility>
 #include <meta/sequence/list.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/rotate.hpp
+++ b/include/meta/sequence/rotate.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/sequence/details/rotate_helper.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/size.hpp
+++ b/include/meta/sequence/size.hpp
@@ -8,7 +8,7 @@
 #include <meta/utils/integral_constants.hpp>
 #include <meta/sequence/list.hpp>
 
-namespace meta
+namespace doom::meta
 {
     template <typename Sequence>
     struct size;

--- a/include/meta/sequence/split_at.hpp
+++ b/include/meta/sequence/split_at.hpp
@@ -9,7 +9,7 @@
 #include <meta/sequence/take.hpp>
 #include <meta/sequence/drop.hpp>
 
-namespace meta
+namespace doom::meta
 {
     template <typename Sequence, typename N>
     using split_at = meta::list<meta::take<Sequence, N>, meta::drop<Sequence, N>>;

--- a/include/meta/sequence/tail.hpp
+++ b/include/meta/sequence/tail.hpp
@@ -8,7 +8,7 @@
 #include <meta/utils/integral_constants.hpp>
 #include <meta/sequence/drop.hpp>
 
-namespace meta
+namespace doom::meta
 {
     template <typename Sequence>
     using tail = drop<Sequence, size_constant<1>>;

--- a/include/meta/sequence/take.hpp
+++ b/include/meta/sequence/take.hpp
@@ -10,7 +10,7 @@
 #include <meta/sequence/rotate.hpp>
 #include <meta/sequence/size.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/unordered_map.hpp
+++ b/include/meta/sequence/unordered_map.hpp
@@ -7,7 +7,7 @@
 
 #include <meta/utils/pair.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/unzip.hpp
+++ b/include/meta/sequence/unzip.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/utils/pair.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/sequence/zip.hpp
+++ b/include/meta/sequence/zip.hpp
@@ -8,7 +8,7 @@
 #include <meta/sequence/list.hpp>
 #include <meta/utils/pair.hpp>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/utils/allow_copy_move_operations.hpp
+++ b/include/meta/utils/allow_copy_move_operations.hpp
@@ -5,7 +5,7 @@
 #ifndef META_UTILS_ALLOW_COPY_MOVE_OPERATIONS_HPP
 #define META_UTILS_ALLOW_COPY_MOVE_OPERATIONS_HPP
 
-namespace meta
+namespace doom::meta
 {
     template <typename T, bool>
     class allow_move_construction_if : public T

--- a/include/meta/utils/enum_bitwise_ops.hpp
+++ b/include/meta/utils/enum_bitwise_ops.hpp
@@ -7,7 +7,7 @@
 
 #include <type_traits>
 
-namespace meta::enum_ops
+namespace doom::meta::enum_ops
 {
     template <typename T>
     struct enable_for : std::false_type
@@ -24,7 +24,7 @@ namespace meta::enum_ops
  * This clearly is meh :/
  */
 #define ENABLE_BITWISE_OPS_FOR(T)                                                                       \
-    namespace meta::enum_ops                                                                            \
+    namespace doom::meta::enum_ops                                                                      \
     {                                                                                                   \
         template <>                                                                                     \
         struct enable_for<T> : std::true_type                                                           \
@@ -34,7 +34,7 @@ namespace meta::enum_ops
 
 #define MAKE_ENUM_BINARY_OPERATOR(op)                                                                   \
     template <typename Enum,                                                                            \
-        typename = std::enable_if_t<std::is_enum_v<Enum> && meta::enum_ops::enable_for_v<Enum>>         \
+        typename = std::enable_if_t<std::is_enum_v<Enum> && doom::meta::enum_ops::enable_for_v<Enum>>   \
     >                                                                                                   \
     constexpr Enum operator op(Enum a, Enum b)                                                          \
     {                                                                                                   \
@@ -53,7 +53,7 @@ MAKE_ENUM_BINARY_OPERATOR(^);
 
 #define MAKE_ENUM_ASSIGN_OPERATOR(op)                                                                   \
     template <typename Enum,                                                                            \
-        typename = std::enable_if_t<std::is_enum_v<Enum> && meta::enum_ops::enable_for_v<Enum>>         \
+        typename = std::enable_if_t<std::is_enum_v<Enum> && doom::meta::enum_ops::enable_for_v<Enum>>   \
     >                                                                                                   \
     constexpr Enum &operator op##=(Enum &a, Enum b)                                                     \
     {                                                                                                   \
@@ -69,7 +69,7 @@ MAKE_ENUM_ASSIGN_OPERATOR(^);
 
 #undef MAKE_ENUM_ASSIGN_OPERATOR
 
-template <typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum> && meta::enum_ops::enable_for_v<Enum>>>
+template <typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum> && doom::meta::enum_ops::enable_for_v<Enum>>>
 constexpr Enum operator~(Enum a)
 {
     using underlying_type = std::underlying_type_t<Enum>;

--- a/include/meta/utils/integral_constants.hpp
+++ b/include/meta/utils/integral_constants.hpp
@@ -8,7 +8,7 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace meta
+namespace doom::meta
 {
     /** std::integral_constant-like types and metafunctions to operate on them */
 

--- a/include/meta/utils/meta_functions.hpp
+++ b/include/meta/utils/meta_functions.hpp
@@ -5,7 +5,7 @@
 #ifndef META_UTILS_META_FUNCTIONS_HPP
 #define META_UTILS_META_FUNCTIONS_HPP
 
-namespace meta
+namespace doom::meta
 {
     template <typename T>
     using identity = T;

--- a/include/meta/utils/overload_set.hpp
+++ b/include/meta/utils/overload_set.hpp
@@ -7,7 +7,7 @@
 
 #include <utility>
 
-namespace meta
+namespace doom::meta
 {
     /**
      * Helper template to form an overload set from functions or function objects

--- a/include/meta/utils/pair.hpp
+++ b/include/meta/utils/pair.hpp
@@ -5,7 +5,7 @@
 #ifndef META_UTILS_PAIR_HPP
 #define META_UTILS_PAIR_HPP
 
-namespace meta
+namespace doom::meta
 {
     template <typename T, typename U>
     struct pair

--- a/include/meta/utils/priority_tag.hpp
+++ b/include/meta/utils/priority_tag.hpp
@@ -7,7 +7,7 @@
 
 #include <cstddef>
 
-namespace meta
+namespace doom::meta
 {
     template <std::size_t I>
     struct priority_tag : priority_tag<I - 1>

--- a/include/meta/utils/rebind.hpp
+++ b/include/meta/utils/rebind.hpp
@@ -5,7 +5,7 @@
 #ifndef META_UTILS_REBIND_HPP
 #define META_UTILS_REBIND_HPP
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/include/meta/utils/recursive_adaptor.hpp
+++ b/include/meta/utils/recursive_adaptor.hpp
@@ -8,7 +8,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace meta
+namespace doom::meta
 {
     /**
      * Adaptor to allow recursion for function objects that don't support it natively (e.g. lambdas)

--- a/include/meta/utils/tuple_for_each.hpp
+++ b/include/meta/utils/tuple_for_each.hpp
@@ -8,7 +8,7 @@
 #include <utility>
 #include <tuple>
 
-namespace meta
+namespace doom::meta
 {
     namespace details
     {

--- a/tests/tests-detection.cpp
+++ b/tests/tests-detection.cpp
@@ -19,7 +19,7 @@ namespace
     };
 }
 
-static_assert(meta::is_detected_v<member_type_test_detector, with_test_member_type>);
-static_assert(!meta::is_detected_v<member_type_test_detector, without_test_member_type>);
-static_assert(std::is_same_v<meta::type_unless_detected_t<void, member_type_test_detector, with_test_member_type>, int>);
-static_assert(std::is_same_v<meta::type_unless_detected_t<void, member_type_test_detector, without_test_member_type>, void>);
+static_assert(doom::meta::is_detected_v<member_type_test_detector, with_test_member_type>);
+static_assert(!doom::meta::is_detected_v<member_type_test_detector, without_test_member_type>);
+static_assert(std::is_same_v<doom::meta::type_unless_detected_t<void, member_type_test_detector, with_test_member_type>, int>);
+static_assert(std::is_same_v<doom::meta::type_unless_detected_t<void, member_type_test_detector, without_test_member_type>, void>);

--- a/tests/tests-integral_constants.cpp
+++ b/tests/tests-integral_constants.cpp
@@ -5,12 +5,12 @@
 #include <type_traits>
 #include <meta/utils/integral_constants.hpp>
 
-using three = meta::plus<meta::size_constant<1>, meta::size_constant<2>>;
-static_assert(std::is_same_v<three, meta::size_constant<3>>);
+using three = doom::meta::plus<doom::meta::size_constant<1>, doom::meta::size_constant<2>>;
+static_assert(std::is_same_v<three, doom::meta::size_constant<3>>);
 
-using four = meta::plus<meta::size_constant<3>, std::integral_constant<char, 1>>;
-static_assert(std::is_same_v<four, meta::size_constant<4>>);
+using four = doom::meta::plus<doom::meta::size_constant<3>, std::integral_constant<char, 1>>;
+static_assert(std::is_same_v<four, doom::meta::size_constant<4>>);
 
-using minus_one = meta::minus <std::integral_constant<int, 3>, std::integral_constant<int, 4>>;
+using minus_one = doom::meta::minus <std::integral_constant<int, 3>, std::integral_constant<int, 4>>;
 static_assert(std::is_same_v<minus_one , std::integral_constant<int, -1>>);
 

--- a/tests/tests-meta_functions.cpp
+++ b/tests/tests-meta_functions.cpp
@@ -7,17 +7,17 @@
 #include <meta/utils/meta_functions.hpp>
 #include <meta/utils/integral_constants.hpp>
 
-static_assert(std::is_same_v<meta::identity<int>, int>);
+static_assert(std::is_same_v<doom::meta::identity<int>, int>);
 
 template <typename T>
-using div_by_two = meta::divides<T, meta::size_constant<2>>;
+using div_by_two = doom::meta::divides<T, doom::meta::size_constant<2>>;
 
 template <typename T>
-using div_by_four = typename meta::compose<div_by_two, div_by_two>::template func<T>;
+using div_by_four = typename doom::meta::compose<div_by_two, div_by_two>::template func<T>;
 
-static_assert(div_by_four<meta::size_constant<4>>::value == 1);
+static_assert(div_by_four<doom::meta::size_constant<4>>::value == 1);
 
-static_assert(std::is_same_v<meta::if_c<true, int, char>, int>);
-static_assert(std::is_same_v<meta::if_c<false, int, char>, char>);
-static_assert(std::is_same_v<meta::if_<meta::size_constant<2>, int, char>, int>);
-static_assert(std::is_same_v<meta::if_<meta::size_constant<0>, int, char>, char>);
+static_assert(std::is_same_v<doom::meta::if_c<true, int, char>, int>);
+static_assert(std::is_same_v<doom::meta::if_c<false, int, char>, char>);
+static_assert(std::is_same_v<doom::meta::if_<doom::meta::size_constant<2>, int, char>, int>);
+static_assert(std::is_same_v<doom::meta::if_<doom::meta::size_constant<0>, int, char>, char>);

--- a/tests/tests-overload_set.cpp
+++ b/tests/tests-overload_set.cpp
@@ -7,7 +7,7 @@
 
 TEST(utils, overload_set)
 {
-    constexpr auto set1 = meta::make_overload_set([](const int &i) {
+    constexpr auto set1 = doom::meta::make_overload_set([](const int &i) {
         ASSERT_EQ(i, 1);
     }, [](const double &d) {
         ASSERT_EQ(d, 2.3);
@@ -15,7 +15,7 @@ TEST(utils, overload_set)
     set1(1);
     set1(2.3);
 
-    constexpr auto set2 = meta::make_overload_set([](int i) {
+    constexpr auto set2 = doom::meta::make_overload_set([](int i) {
         return i;
     }, [](auto &&) {
         return 0;

--- a/tests/tests-priority_tag.cpp
+++ b/tests/tests-priority_tag.cpp
@@ -6,17 +6,17 @@
 #include <meta/utils/priority_tag.hpp>
 
 template <typename T, typename = std::enable_if_t<std::is_same_v<int, T>>>
-static constexpr int dummy([[maybe_unused]] T unused, meta::priority_tag<1>)
+static constexpr int dummy([[maybe_unused]] T unused, doom::meta::priority_tag<1>)
 {
     return 1;
 }
 
 template <typename T>
-static constexpr int dummy([[maybe_unused]] T unused, meta::priority_tag<0>)
+static constexpr int dummy([[maybe_unused]] T unused, doom::meta::priority_tag<0>)
 {
     return 2;
 }
 
-static_assert(dummy(-2, meta::priority_tag<1>{}) == 1);
-static_assert(dummy(3.2, meta::priority_tag<1>{}) == 2);
-static_assert(dummy(-2, meta::priority_tag<0>{}) == 2);
+static_assert(dummy(-2, doom::meta::priority_tag<1>{}) == 1);
+static_assert(dummy(3.2, doom::meta::priority_tag<1>{}) == 2);
+static_assert(dummy(-2, doom::meta::priority_tag<0>{}) == 2);

--- a/tests/tests-rebind.cpp
+++ b/tests/tests-rebind.cpp
@@ -10,9 +10,9 @@
 #include <meta/sequence/list.hpp>
 
 using t = std::tuple<int, char, bool>;
-using v = meta::rebind<t, std::variant>;
+using v = doom::meta::rebind<t, std::variant>;
 static_assert(std::is_same_v<v, std::variant<int, char, bool>>);
 
-using lst = meta::list<int, std::allocator<int>>;
-using vec = meta::rebind<lst, std::vector>;
+using lst = doom::meta::list<int, std::allocator<int>>;
+using vec = doom::meta::rebind<lst, std::vector>;
 static_assert(std::is_same_v<vec, std::vector<int, std::allocator<int>>>);

--- a/tests/tests-recursive_adaptor.cpp
+++ b/tests/tests-recursive_adaptor.cpp
@@ -8,7 +8,7 @@
 
 TEST(utils, recursive_adaptor)
 {
-    constexpr auto fact = meta::recursive_adaptor([](auto &&self, int n) constexpr -> int {
+    constexpr auto fact = doom::meta::recursive_adaptor([](auto &&self, int n) constexpr -> int {
         if (n <= 1)
             return 1;
         return n * self(n - 1);
@@ -16,7 +16,7 @@ TEST(utils, recursive_adaptor)
     static_assert(fact(1) == 1);
     static_assert(fact(3) == 6);
 
-    constexpr auto test = meta::recursive_adaptor(meta::make_overload_set([](auto &&self, int n) constexpr -> int {
+    constexpr auto test = doom::meta::recursive_adaptor(doom::meta::make_overload_set([](auto &&self, int n) constexpr -> int {
         if (n <= 1)
             return 1;
         return n * self(n - 1);

--- a/tests/tests-tuple_for_each.cpp
+++ b/tests/tests-tuple_for_each.cpp
@@ -12,22 +12,22 @@ TEST(utils, tuple_for_each)
     int sum = 0;
     std::tuple<int, int, int> t1{1, 2, 3};
 
-    meta::tuple_for_each(t1, [&sum](auto &&v) {
+    doom::meta::tuple_for_each(t1, [&sum](auto &&v) {
         sum += v;
     });
     ASSERT_EQ(sum, 6);
 
-    meta::tuple_for_each(t1, [](auto &&v) {
+    doom::meta::tuple_for_each(t1, [](auto &&v) {
         static_assert(std::is_same_v<decltype(v), int &>);
     });
 
-    meta::tuple_for_each(std::move(t1), [](auto &&v) {
+    doom::meta::tuple_for_each(std::move(t1), [](auto &&v) {
         static_assert(std::is_same_v<decltype(v), int &&>);
     });
 
     const std::tuple<int, int, int> t2{1, 2, 3};
 
-    meta::tuple_for_each(t2, [](auto &&v) {
+    doom::meta::tuple_for_each(t2, [](auto &&v) {
         static_assert(std::is_same_v<decltype(v), const int &>);
     });
 }

--- a/tests/tests-type_list.cpp
+++ b/tests/tests-type_list.cpp
@@ -6,20 +6,20 @@
 #include <meta/utils/integral_constants.hpp>
 #include <meta/sequence/sequence.hpp>
 
-using meta::size_constant;
+using doom::meta::size_constant;
 
-static_assert(meta::size<meta::list<int, char, bool>>::value == 3);
-static_assert(meta::size<meta::list<int, char>>::value == 2);
-static_assert(meta::size<meta::list<>>::value == 0);
+static_assert(doom::meta::size<doom::meta::list<int, char, bool>>::value == 3);
+static_assert(doom::meta::size<doom::meta::list<int, char>>::value == 2);
+static_assert(doom::meta::size<doom::meta::list<>>::value == 0);
 
-using A = meta::list<int, char>;
-using B = meta::list<double, float>;
-using C = meta::join<A, B>;
-static_assert(std::is_same_v<meta::list<int, char, double, float>, C>);
+using A = doom::meta::list<int, char>;
+using B = doom::meta::list<double, float>;
+using C = doom::meta::join<A, B>;
+static_assert(std::is_same_v<doom::meta::list<int, char, double, float>, C>);
 
-using int_char_bool = meta::list<int, char, bool>;
+using int_char_bool = doom::meta::list<int, char, bool>;
 
-using regular_types = meta::list<
+using regular_types = doom::meta::list<
     int, char, bool, double, float, int, char, bool, double, float,
     int, char, bool, double, float, int, char, bool, double, float,
     int, char, bool, double, float, int, char, bool, double, float,
@@ -34,7 +34,7 @@ using regular_types = meta::list<
     int, char, bool, double, float, int, char, bool, double, float
 >;
 
-using pointer_types = meta::list<
+using pointer_types = doom::meta::list<
     int *, char *, bool *, double *, float *, int *, char *, bool *, double *, float *,
     int *, char *, bool *, double *, float *, int *, char *, bool *, double *, float *,
     int *, char *, bool *, double *, float *, int *, char *, bool *, double *, float *,
@@ -49,33 +49,33 @@ using pointer_types = meta::list<
     int *, char *, bool *, double *, float *, int *, char *, bool *, double *, float *
 >;
 
-using D = meta::map<std::add_pointer_t, regular_types>;
+using D = doom::meta::map<std::add_pointer_t, regular_types>;
 static_assert(std::is_same_v<D, pointer_types>);
 
-using E = meta::list<int, int *, char, char *, float *, float &>;
+using E = doom::meta::list<int, int *, char, char *, float *, float &>;
 
-static_assert(std::is_same_v<meta::list<>, meta::filter<std::is_pointer, regular_types>>);
-static_assert(std::is_same_v<meta::list<>, meta::filter<std::is_void, regular_types>>);
-static_assert(std::is_same_v<meta::list<>, meta::filter<std::is_reference, regular_types>>);
-static_assert(std::is_same_v<pointer_types, meta::filter<std::is_pointer, pointer_types>>);
-static_assert(std::is_same_v<meta::list<int *, char *, float *>, meta::filter<std::is_pointer, E>>);
+static_assert(std::is_same_v<doom::meta::list<>, doom::meta::filter<std::is_pointer, regular_types>>);
+static_assert(std::is_same_v<doom::meta::list<>, doom::meta::filter<std::is_void, regular_types>>);
+static_assert(std::is_same_v<doom::meta::list<>, doom::meta::filter<std::is_reference, regular_types>>);
+static_assert(std::is_same_v<pointer_types, doom::meta::filter<std::is_pointer, pointer_types>>);
+static_assert(std::is_same_v<doom::meta::list<int *, char *, float *>, doom::meta::filter<std::is_pointer, E>>);
 
-static_assert(std::is_same_v<meta::at<E, size_constant<2>>, char>);
-static_assert(std::is_same_v<meta::at<E, size_constant<0>>, int>);
-static_assert(std::is_same_v<meta::at<pointer_types, size_constant<30>>, int *>);
-static_assert(std::is_same_v<meta::at<regular_types, size_constant<30>>, int>);
+static_assert(std::is_same_v<doom::meta::at<E, size_constant<2>>, char>);
+static_assert(std::is_same_v<doom::meta::at<E, size_constant<0>>, int>);
+static_assert(std::is_same_v<doom::meta::at<pointer_types, size_constant<30>>, int *>);
+static_assert(std::is_same_v<doom::meta::at<regular_types, size_constant<30>>, int>);
 
-static_assert(meta::all<std::is_pointer, pointer_types>::value);
-static_assert(not meta::all<std::is_pointer, regular_types>::value);
-static_assert(not meta::all<std::is_pointer, E>::value);
+static_assert(doom::meta::all<std::is_pointer, pointer_types>::value);
+static_assert(not doom::meta::all<std::is_pointer, regular_types>::value);
+static_assert(not doom::meta::all<std::is_pointer, E>::value);
 
-static_assert(meta::any<std::is_pointer, pointer_types>::value);
-static_assert(not meta::any<std::is_pointer, regular_types>::value);
-static_assert(meta::any<std::is_pointer, E>::value);
+static_assert(doom::meta::any<std::is_pointer, pointer_types>::value);
+static_assert(not doom::meta::any<std::is_pointer, regular_types>::value);
+static_assert(doom::meta::any<std::is_pointer, E>::value);
 
-static_assert(not meta::none<std::is_pointer, pointer_types>::value);
-static_assert(meta::none<std::is_pointer, regular_types>::value);
-static_assert(not meta::none<std::is_pointer, E>::value);
+static_assert(not doom::meta::none<std::is_pointer, pointer_types>::value);
+static_assert(doom::meta::none<std::is_pointer, regular_types>::value);
+static_assert(not doom::meta::none<std::is_pointer, E>::value);
 
 template <int i>
 using int_ = std::integral_constant<int, i>;
@@ -83,7 +83,7 @@ using int_ = std::integral_constant<int, i>;
 template <typename A, typename B>
 using meta_add = int_<A::value + B::value>;
 
-using nums = meta::list<
+using nums = doom::meta::list<
     int_<0>, int_<1>, int_<2>, int_<3>, int_<4>, int_<5>, int_<6>, int_<7>, int_<8>, int_<9>, int_<10>,
     int_<11>, int_<12>, int_<13>, int_<14>, int_<15>, int_<16>, int_<17>, int_<18>, int_<19>, int_<20>,
     int_<21>, int_<22>, int_<23>, int_<24>, int_<25>, int_<26>, int_<27>, int_<28>, int_<29>, int_<30>,
@@ -96,37 +96,37 @@ using nums = meta::list<
     int_<91>, int_<92>, int_<93>, int_<94>, int_<95>, int_<96>, int_<97>, int_<98>, int_<99>, int_<100>,
     int_<101>, int_<102>, int_<103>, int_<104>, int_<105>, int_<106>, int_<107>, int_<108>, int_<109>, int_<110>,
     int_<111>, int_<112>, int_<113>, int_<114>, int_<115>, int_<116>, int_<117>, int_<118>, int_<119>>;
-static_assert(meta::foldl<meta_add, int_<0>, nums>::value == 7140);
+static_assert(doom::meta::foldl<meta_add, int_<0>, nums>::value == 7140);
 
-static_assert(std::is_same_v<meta::head<nums>, int_<0>>);
-static_assert(std::is_same_v<meta::last<nums>, int_<119>>);
-static_assert(std::is_same_v<meta::tail<int_char_bool>, meta::list<char, bool>>);
+static_assert(std::is_same_v<doom::meta::head<nums>, int_<0>>);
+static_assert(std::is_same_v<doom::meta::last<nums>, int_<119>>);
+static_assert(std::is_same_v<doom::meta::tail<int_char_bool>, doom::meta::list<char, bool>>);
 
-static_assert(std::is_same_v<meta::cons<int, meta::list<>>, meta::list<int>>);
-static_assert(std::is_same_v<meta::cons<int, meta::list<char, bool>>, int_char_bool>);
+static_assert(std::is_same_v<doom::meta::cons<int, doom::meta::list<>>, doom::meta::list<int>>);
+static_assert(std::is_same_v<doom::meta::cons<int, doom::meta::list<char, bool>>, int_char_bool>);
 
-static_assert(std::is_same_v<meta::rotate<int_char_bool, size_constant<1>>, meta::list<char, bool, int>>);
-static_assert(std::is_same_v<meta::rotate<int_char_bool, size_constant<4>>, meta::list<char, bool, int>>);
-static_assert(std::is_same_v<meta::rotate<pointer_types, size_constant<10>>, pointer_types>);
+static_assert(std::is_same_v<doom::meta::rotate<int_char_bool, size_constant<1>>, doom::meta::list<char, bool, int>>);
+static_assert(std::is_same_v<doom::meta::rotate<int_char_bool, size_constant<4>>, doom::meta::list<char, bool, int>>);
+static_assert(std::is_same_v<doom::meta::rotate<pointer_types, size_constant<10>>, pointer_types>);
 
-static_assert(std::is_same_v<meta::drop<int_char_bool, size_constant<1>>, meta::list<char, bool>>);
-static_assert(std::is_same_v<meta::drop<int_char_bool, size_constant<40>>, meta::list<>>);
-static_assert(meta::foldl<meta_add, int_<0>, meta::drop<nums, size_constant<11>>>::value == 7085);
+static_assert(std::is_same_v<doom::meta::drop<int_char_bool, size_constant<1>>, doom::meta::list<char, bool>>);
+static_assert(std::is_same_v<doom::meta::drop<int_char_bool, size_constant<40>>, doom::meta::list<>>);
+static_assert(doom::meta::foldl<meta_add, int_<0>, doom::meta::drop<nums, size_constant<11>>>::value == 7085);
 
-static_assert(std::is_same_v<meta::take<int_char_bool, size_constant<0>>, meta::list<>>);
-static_assert(std::is_same_v<meta::take<int_char_bool, size_constant<2>>, meta::list<int, char>>);
-static_assert(std::is_same_v<meta::take<int_char_bool, size_constant<40>>, int_char_bool>);
-static_assert(meta::foldl<meta_add, int_<0>, meta::take<nums, size_constant<11>>>::value == 55);
+static_assert(std::is_same_v<doom::meta::take<int_char_bool, size_constant<0>>, doom::meta::list<>>);
+static_assert(std::is_same_v<doom::meta::take<int_char_bool, size_constant<2>>, doom::meta::list<int, char>>);
+static_assert(std::is_same_v<doom::meta::take<int_char_bool, size_constant<40>>, int_char_bool>);
+static_assert(doom::meta::foldl<meta_add, int_<0>, doom::meta::take<nums, size_constant<11>>>::value == 55);
 
-using F = meta::list<meta::list<int, char>, meta::list<bool>>;
-using G = meta::list<meta::list<int, char, bool>, meta::list<>>;
-static_assert(std::is_same_v<meta::split_at<int_char_bool, size_constant<2>>, F>);
-static_assert(std::is_same_v<meta::split_at<int_char_bool, size_constant<3>>, G>);
+using F = doom::meta::list<doom::meta::list<int, char>, doom::meta::list<bool>>;
+using G = doom::meta::list<doom::meta::list<int, char, bool>, doom::meta::list<>>;
+static_assert(std::is_same_v<doom::meta::split_at<int_char_bool, size_constant<2>>, F>);
+static_assert(std::is_same_v<doom::meta::split_at<int_char_bool, size_constant<3>>, G>);
 
-static_assert(std::is_same_v<meta::append<int_char_bool, int>, meta::list<int, char, bool, int>>);
+static_assert(std::is_same_v<doom::meta::append<int_char_bool, int>, doom::meta::list<int, char, bool, int>>);
 
-static_assert(std::is_same_v<meta::insert_at<int_char_bool, size_constant<2>, int>, meta::list<int, char, int, bool>>);
-static_assert(std::is_same_v<meta::insert_at<int_char_bool, size_constant<0>, int>, meta::list<int, int, char, bool>>);
+static_assert(std::is_same_v<doom::meta::insert_at<int_char_bool, size_constant<2>, int>, doom::meta::list<int, char, int, bool>>);
+static_assert(std::is_same_v<doom::meta::insert_at<int_char_bool, size_constant<0>, int>, doom::meta::list<int, int, char, bool>>);
 
 template <typename T>
 using is_bool = std::is_same<T, bool>;
@@ -143,44 +143,44 @@ using is_118 = std::is_same<int_<118>, T>;
 template <typename T>
 using is_62 = std::is_same<int_<62>, T>;
 
-static_assert(meta::index<is_bool, int_char_bool>::value == 2);
-static_assert(meta::index<is_int, regular_types>::value == 0);
-static_assert(meta::index<is_double, regular_types>::value == 3);
-static_assert(meta::index<is_62, nums>::value == 62);
-static_assert(meta::index<is_118, nums>::value == 118);
-static_assert(meta::index<is_int, meta::list<int>>::value == 0);
+static_assert(doom::meta::index<is_bool, int_char_bool>::value == 2);
+static_assert(doom::meta::index<is_int, regular_types>::value == 0);
+static_assert(doom::meta::index<is_double, regular_types>::value == 3);
+static_assert(doom::meta::index<is_62, nums>::value == 62);
+static_assert(doom::meta::index<is_118, nums>::value == 118);
+static_assert(doom::meta::index<is_int, doom::meta::list<int>>::value == 0);
 
-static_assert(std::is_same_v<meta::drop_at<int_char_bool, int_<0>>, meta::list<char, bool>>);
-static_assert(std::is_same_v<meta::drop_at<int_char_bool, int_<1>>, meta::list<int, bool>>);
+static_assert(std::is_same_v<doom::meta::drop_at<int_char_bool, int_<0>>, doom::meta::list<char, bool>>);
+static_assert(std::is_same_v<doom::meta::drop_at<int_char_bool, int_<1>>, doom::meta::list<int, bool>>);
 
-using H = meta::repeat<int, int_<5>>;
-static_assert(std::is_same_v<H, meta::list<int, int, int, int, int>>);
-static_assert(std::is_same_v<meta::repeat<int, int_<0>>, meta::list<>>);
+using H = doom::meta::repeat<int, int_<5>>;
+static_assert(std::is_same_v<H, doom::meta::list<int, int, int, int, int>>);
+static_assert(std::is_same_v<doom::meta::repeat<int, int_<0>>, doom::meta::list<>>);
 
-using I = meta::replace<is_int, bool, H>;
-static_assert(std::is_same_v<I, meta::list<bool, bool, bool, bool, bool>>);
+using I = doom::meta::replace<is_int, bool, H>;
+static_assert(std::is_same_v<I, doom::meta::list<bool, bool, bool, bool, bool>>);
 
 template <typename A, typename B>
 using int_less = std::bool_constant<A::value<B::value>;
 
-using J = meta::list<int_<3>, int_<2>, int_<1>, int_<5>, int_<1>, int_<3>>;
-static_assert(std::is_same_v<meta::minimum<int_less, nums>, int_<0>>);
-static_assert(std::is_same_v<meta::minimum<int_less, J>, int_<1>>);
+using J = doom::meta::list<int_<3>, int_<2>, int_<1>, int_<5>, int_<1>, int_<3>>;
+static_assert(std::is_same_v<doom::meta::minimum<int_less, nums>, int_<0>>);
+static_assert(std::is_same_v<doom::meta::minimum<int_less, J>, int_<1>>);
 
-using K = meta::zip<meta::list<int_<0>, int_<2>, int_<4>>, meta::list<int_<1>, int_<3>, int_<5>>>;
+using K = doom::meta::zip<doom::meta::list<int_<0>, int_<2>, int_<4>>, doom::meta::list<int_<1>, int_<3>, int_<5>>>;
 static_assert(std::is_same_v<
     K,
-    meta::list<meta::pair<int_<0>, int_<1>>, meta::pair<int_<2>, int_<3>>, meta::pair<int_<4>, int_<5>>>
+    doom::meta::list<doom::meta::pair<int_<0>, int_<1>>, doom::meta::pair<int_<2>, int_<3>>, doom::meta::pair<int_<4>, int_<5>>>
 >);
 
-using L = meta::unzip<K>;
+using L = doom::meta::unzip<K>;
 static_assert(std::is_same_v<
     L,
-    meta::pair<meta::list<int_<0>, int_<2>, int_<4>>, meta::list<int_<1>, int_<3>, int_<5>>>
+    doom::meta::pair<doom::meta::list<int_<0>, int_<2>, int_<4>>, doom::meta::list<int_<1>, int_<3>, int_<5>>>
 >);
 
-using M = meta::replicate<int_<5>, int>;
-static_assert(std::is_same_v<M, meta::list<int, int, int, int, int>>);
+using M = doom::meta::replicate<int_<5>, int>;
+static_assert(std::is_same_v<M, doom::meta::list<int, int, int, int, int>>);
 
-static_assert(std::is_same_v<meta::init<int_char_bool>, meta::list<int, char>>);
-static_assert(std::is_same_v<meta::init<meta::list<int>>, meta::list<>>);
+static_assert(std::is_same_v<doom::meta::init<int_char_bool>, doom::meta::list<int, char>>);
+static_assert(std::is_same_v<doom::meta::init<doom::meta::list<int>>, doom::meta::list<>>);

--- a/tests/tests-type_map.cpp
+++ b/tests/tests-type_map.cpp
@@ -5,129 +5,129 @@
 #include <type_traits>
 #include <meta/sequence/sequence.hpp>
 
-using signed_to_unsigned = meta::unordered_map<
-    meta::pair<signed char, unsigned char>,
-    meta::pair<short, unsigned short>,
-    meta::pair<int, unsigned int>,
-    meta::pair<long, unsigned long>
+using signed_to_unsigned = doom::meta::unordered_map<
+        doom::meta::pair<signed char, unsigned char>,
+        doom::meta::pair<short, unsigned short>,
+        doom::meta::pair<int, unsigned int>,
+        doom::meta::pair<long, unsigned long>
 >;
 
-static_assert(std::is_same_v<meta::at<signed_to_unsigned, signed char>, unsigned char>);
-static_assert(std::is_same_v<meta::at<signed_to_unsigned, short>, unsigned short>);
-static_assert(std::is_same_v<meta::at<signed_to_unsigned, int>, unsigned int>);
-static_assert(std::is_same_v<meta::at<signed_to_unsigned, long>, unsigned long>);
+static_assert(std::is_same_v<doom::meta::at<signed_to_unsigned, signed char>, unsigned char>);
+static_assert(std::is_same_v<doom::meta::at<signed_to_unsigned, short>, unsigned short>);
+static_assert(std::is_same_v<doom::meta::at < signed_to_unsigned, int>, unsigned int > );
+static_assert(std::is_same_v<doom::meta::at < signed_to_unsigned, long>, unsigned long > );
 
-using smaller_to_bigger = meta::unordered_map<
-    meta::pair<char, short>,
-    meta::pair<short, int>,
-    meta::pair<int, long>
+using smaller_to_bigger = doom::meta::unordered_map<
+        doom::meta::pair<char, short>,
+        doom::meta::pair<short, int>,
+        doom::meta::pair<int, long>
 >;
 
-using smaller_to_bigger2 = meta::append<smaller_to_bigger, meta::pair<long, long long>>;
+using smaller_to_bigger2 = doom::meta::append<smaller_to_bigger, doom::meta::pair<long, long long>>;
 
 static_assert(std::is_same_v<
-    smaller_to_bigger2,
-    meta::unordered_map<
-        meta::pair<char, short>,
-        meta::pair<short, int>,
-        meta::pair<int, long>,
-        meta::pair<long, long long>
-    >
+        smaller_to_bigger2,
+        doom::meta::unordered_map<
+                doom::meta::pair<char, short>,
+                doom::meta::pair<short, int>,
+                doom::meta::pair<int, long>,
+                doom::meta::pair<long, long long>
+        >
 >);
 
-static_assert(meta::size<signed_to_unsigned>::value == 4);
-static_assert(meta::size<smaller_to_bigger>::value == 3);
+static_assert(doom::meta::size<signed_to_unsigned>::value == 4);
+static_assert(doom::meta::size<smaller_to_bigger>::value == 3);
 
-template <typename T>
+template<typename T>
 using smaller_than_int = std::bool_constant<sizeof(T) < sizeof(int)>;
 
-template <typename KeyValue>
+template<typename KeyValue>
 using key_smaller_than_int = smaller_than_int<typename KeyValue::first_type>;
 
-using smols = meta::filter<key_smaller_than_int, smaller_to_bigger2>;
+using smols = doom::meta::filter<key_smaller_than_int, smaller_to_bigger2>;
 static_assert(std::is_same_v<
-    smols,
-    meta::unordered_map<
-        meta::pair<char, short>,
-        meta::pair<short, int>
-    >
+        smols,
+        doom::meta::unordered_map<
+                doom::meta::pair<char, short>,
+                doom::meta::pair<short, int>
+        >
 >);
 
-static_assert(meta::all<key_smaller_than_int, smols>::value);
-static_assert(meta::any<key_smaller_than_int, smols>::value);
-static_assert(not meta::all<key_smaller_than_int, smaller_to_bigger2>::value);
-static_assert(meta::any<key_smaller_than_int, smaller_to_bigger2>::value);
+static_assert(doom::meta::all<key_smaller_than_int, smols>::value);
+static_assert(doom::meta::any<key_smaller_than_int, smols>::value);
+static_assert(not doom::meta::all<key_smaller_than_int, smaller_to_bigger2>::value);
+static_assert(doom::meta::any<key_smaller_than_int, smaller_to_bigger2>::value);
 
-template <int Value>
+template<int Value>
 using int_ = std::integral_constant<int, Value>;
 
-using numbers_identity = meta::unordered_map<
-    meta::pair<int_<0>, int_<0>>,
-    meta::pair<int_<1>, int_<1>>,
-    meta::pair<int_<2>, int_<2>>,
-    meta::pair<int_<3>, int_<3>>,
-    meta::pair<int_<4>, int_<4>>,
-    meta::pair<int_<5>, int_<5>>,
-    meta::pair<int_<6>, int_<6>>,
-    meta::pair<int_<7>, int_<7>>,
-    meta::pair<int_<8>, int_<8>>,
-    meta::pair<int_<9>, int_<9>>,
-    meta::pair<int_<10>, int_<10>>,
-    meta::pair<int_<11>, int_<11>>,
-    meta::pair<int_<12>, int_<12>>,
-    meta::pair<int_<13>, int_<13>>,
-    meta::pair<int_<14>, int_<14>>,
-    meta::pair<int_<15>, int_<15>>,
-    meta::pair<int_<16>, int_<16>>,
-    meta::pair<int_<17>, int_<17>>,
-    meta::pair<int_<18>, int_<18>>,
-    meta::pair<int_<19>, int_<19>>
+using numbers_identity = doom::meta::unordered_map<
+        doom::meta::pair<int_<0>, int_<0>>,
+        doom::meta::pair<int_<1>, int_<1>>,
+        doom::meta::pair<int_<2>, int_<2>>,
+        doom::meta::pair<int_<3>, int_<3>>,
+        doom::meta::pair<int_<4>, int_<4>>,
+        doom::meta::pair<int_<5>, int_<5>>,
+        doom::meta::pair<int_<6>, int_<6>>,
+        doom::meta::pair<int_<7>, int_<7>>,
+        doom::meta::pair<int_<8>, int_<8>>,
+        doom::meta::pair<int_<9>, int_<9>>,
+        doom::meta::pair<int_<10>, int_<10>>,
+        doom::meta::pair<int_<11>, int_<11>>,
+        doom::meta::pair<int_<12>, int_<12>>,
+        doom::meta::pair<int_<13>, int_<13>>,
+        doom::meta::pair<int_<14>, int_<14>>,
+        doom::meta::pair<int_<15>, int_<15>>,
+        doom::meta::pair<int_<16>, int_<16>>,
+        doom::meta::pair<int_<17>, int_<17>>,
+        doom::meta::pair<int_<18>, int_<18>>,
+        doom::meta::pair<int_<19>, int_<19>>
 >;
 
-template <typename T>
+template<typename T>
 using double_int_ = int_<T::value * 2>;
 
-template <typename KeyValue>
-using double_value = meta::pair<typename KeyValue::first_type, double_int_<typename KeyValue::second_type>>;
+template<typename KeyValue>
+using double_value = doom::meta::pair<typename KeyValue::first_type, double_int_<typename KeyValue::second_type>>;
 
-using numbers_double = meta::map<double_value, numbers_identity>;
+using numbers_double = doom::meta::map<double_value, numbers_identity>;
 
-template <typename Double, typename Simple>
+template<typename Double, typename Simple>
 using is_double_of = std::bool_constant<Double::value == 2 * Simple::value>;
 
-template <typename KeyValue>
+template<typename KeyValue>
 using is_value_double_of_key = is_double_of<typename KeyValue::second_type, typename KeyValue::first_type>;
 
-static_assert(meta::all<is_value_double_of_key, numbers_double>::value);
-static_assert(std::is_same_v<numbers_double, meta::unordered_map<
-    meta::pair<int_<0>, int_<0>>,
-    meta::pair<int_<1>, int_<2>>,
-    meta::pair<int_<2>, int_<4>>,
-    meta::pair<int_<3>, int_<6>>,
-    meta::pair<int_<4>, int_<8>>,
-    meta::pair<int_<5>, int_<10>>,
-    meta::pair<int_<6>, int_<12>>,
-    meta::pair<int_<7>, int_<14>>,
-    meta::pair<int_<8>, int_<16>>,
-    meta::pair<int_<9>, int_<18>>,
-    meta::pair<int_<10>, int_<20>>,
-    meta::pair<int_<11>, int_<22>>,
-    meta::pair<int_<12>, int_<24>>,
-    meta::pair<int_<13>, int_<26>>,
-    meta::pair<int_<14>, int_<28>>,
-    meta::pair<int_<15>, int_<30>>,
-    meta::pair<int_<16>, int_<32>>,
-    meta::pair<int_<17>, int_<34>>,
-    meta::pair<int_<18>, int_<36>>,
-    meta::pair<int_<19>, int_<38>>
+static_assert(doom::meta::all<is_value_double_of_key, numbers_double>::value);
+static_assert(std::is_same_v<numbers_double, doom::meta::unordered_map<
+        doom::meta::pair<int_<0>, int_<0>>,
+        doom::meta::pair<int_<1>, int_<2>>,
+        doom::meta::pair<int_<2>, int_<4>>,
+        doom::meta::pair<int_<3>, int_<6>>,
+        doom::meta::pair<int_<4>, int_<8>>,
+        doom::meta::pair<int_<5>, int_<10>>,
+        doom::meta::pair<int_<6>, int_<12>>,
+        doom::meta::pair<int_<7>, int_<14>>,
+        doom::meta::pair<int_<8>, int_<16>>,
+        doom::meta::pair<int_<9>, int_<18>>,
+        doom::meta::pair<int_<10>, int_<20>>,
+        doom::meta::pair<int_<11>, int_<22>>,
+        doom::meta::pair<int_<12>, int_<24>>,
+        doom::meta::pair<int_<13>, int_<26>>,
+        doom::meta::pair<int_<14>, int_<28>>,
+        doom::meta::pair<int_<15>, int_<30>>,
+        doom::meta::pair<int_<16>, int_<32>>,
+        doom::meta::pair<int_<17>, int_<34>>,
+        doom::meta::pair<int_<18>, int_<36>>,
+        doom::meta::pair<int_<19>, int_<38>>
 >>);
 
-template <typename A, typename B>
+template<typename A, typename B>
 using add_ints = int_<A::value + B::value>;
 
-template <typename Accumulator, typename KeyValue>
+template<typename Accumulator, typename KeyValue>
 using add_keys = add_ints<Accumulator, typename KeyValue::first_type>;
 
-using sum_of_keys = meta::foldl<add_keys, int_<0>, numbers_double>;
+using sum_of_keys = doom::meta::foldl<add_keys, int_<0>, numbers_double>;
 
 static_assert(sum_of_keys::value == 190);


### PR DESCRIPTION
that use meta namespace